### PR TITLE
Remove secular accomplishments section and apply cooler editorial styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,739 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
+:root {
+  font-family: 'Crimson Pro', 'Libre Baskerville', Georgia, serif;
+  line-height: 1.6;
+  color: #1a1a1a;
+  background: #f7f8fb;
+}
+
+body {
+  margin: 0;
+}
+
+.login-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.login-card {
+  width: min(460px, 100%);
+  background: #fff;
+  border-radius: 1.25rem;
   padding: 2rem;
-  text-align: center;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 1rem 4rem;
+  background: #f7f8fb;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.hero {
+  background: linear-gradient(135deg, #2d3748 0%, #1f2937 100%);
+  color: #f8fafc;
+  border-radius: 0.5rem;
+  padding: 3rem 2.5rem 2.5rem;
+  margin: 2rem 0 3rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.14);
+}
+
+.hero-top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.logout-button {
+  background: #f1f5f9;
+  color: #1e293b;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.logout-button:hover {
+  background: #e2e8f0;
+  transform: translateY(-1px);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  opacity: 0.9;
+  margin: 0;
+  font-weight: 700;
+}
+
+.github-banner-link {
+  display: block;
+  margin-bottom: 1.25rem;
+}
+
+.github-banner {
+  width: 100%;
+  max-width: 620px;
+  border-radius: 0.75rem;
+  display: block;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.default-highlights {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.highlight-card,
+.mini-highlight {
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.highlight-card {
+  padding: 1.5rem;
+}
+
+.highlight-card h2 {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.highlight-label {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+  font-weight: 700;
+}
+
+.highlight-meta,
+.highlight-note {
+  font-weight: 600;
+  color: #334155;
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+
+.mini-highlight {
+  padding: 1rem 1.1rem;
+}
+
+.mini-highlight h3 {
+  margin: 0 0 0.55rem;
+  font-size: 1.05rem;
+}
+
+.mini-brand {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mini-title {
+  margin: 0.2rem 0;
+  font-weight: 700;
+}
+
+
+.mini-highlight a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.mini-highlight a:hover {
+  text-decoration: underline;
+}
+/* Platform-inspired resource cards with masonry layout */
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.resource-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.resource-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  border-color: #cbd5e1;
+}
+
+/* Amazon-inspired (orange accent) */
+.resource-card:nth-child(1) {
+  border-left: 4px solid #ff9900;
+  background: linear-gradient(135deg, #fff 0%, #fffbf5 100%);
+}
+
+/* StoryGraph-inspired (purple accent) */
+.resource-card:nth-child(2) {
+  border-left: 4px solid #8b5cf6;
+  background: linear-gradient(135deg, #fff 0%, #faf5ff 100%);
+  grid-row: span 2;
+}
+
+/* Beli/Food-inspired (green accent) */
+.resource-card:nth-child(3) {
+  border-left: 4px solid #10b981;
+  background: linear-gradient(135deg, #fff 0%, #f0fdf4 100%);
+}
+
+/* Stash/Gaming-inspired (blue accent) */
+.resource-card:nth-child(4) {
+  border-left: 4px solid #3b82f6;
+  background: linear-gradient(135deg, #fff 0%, #eff6ff 100%);
+}
+
+/* Letterboxd-inspired (teal accent) */
+.resource-card:nth-child(5) {
+  border-left: 4px solid #14b8a6;
+  background: linear-gradient(135deg, #fff 0%, #f0fdfa 100%);
+  grid-row: span 2;
+}
+
+/* GitHub-inspired (dark accent) */
+.resource-card:nth-child(6) {
+  border-left: 4px solid #24292f;
+  background: linear-gradient(135deg, #fff 0%, #f6f8fa 100%);
+}
+
+/* LinkedIn-inspired (blue accent) */
+.resource-card:nth-child(7) {
+  border-left: 4px solid #0a66c2;
+  background: linear-gradient(135deg, #fff 0%, #f3f6f8 100%);
+}
+
+
+/* Islamic blog-inspired (emerald accent) */
+.resource-card:nth-child(8) {
+  border-left: 4px solid #0f766e;
+  background: linear-gradient(135deg, #fff 0%, #f0fdfa 100%);
+}
+
+/* Philosophy blog-inspired (violet accent) */
+.resource-card:nth-child(9) {
+  border-left: 4px solid #7c3aed;
+  background: linear-gradient(135deg, #fff 0%, #f5f3ff 100%);
+}
+
+/* Humanities blog-inspired (amber accent) */
+.resource-card:nth-child(10) {
+  border-left: 4px solid #d97706;
+  background: linear-gradient(135deg, #fff 0%, #fffbeb 100%);
+}
+
+.resource-card h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.resource-card p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.resource-card a {
+  color: #3b82f6;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color 0.2s;
+}
+
+.resource-card a:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.resource-card a::after {
+  content: '→';
+  font-size: 1.1em;
+}
+
+
+.hero h1,
+.resource-card h2,
+.gallery-section h2,
+.source-card h2,
+.feed-card h2,
+.manual-panel h3 {
+  font-family: 'Playfair Display', 'Crimson Pro', Georgia, serif;
+}
+
+.resource-card:nth-child(1) { grid-column: span 12; }
+.resource-card:nth-child(2),
+.resource-card:nth-child(3) { grid-column: span 6; }
+.resource-card:nth-child(4),
+.resource-card:nth-child(5),
+.resource-card:nth-child(6) { grid-column: span 4; }
+.resource-card:nth-child(7),
+.resource-card:nth-child(8),
+.resource-card:nth-child(9),
+.resource-card:nth-child(10) { grid-column: span 6; }
+
+.feed-card { grid-column: span 4; }
+.feed-card:first-child { grid-column: span 8; }
+
+/* Gallery sections */
+.gallery-section {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  margin-bottom: 2rem;
+  border: 1px solid #e2e8f0;
+}
+
+.gallery-section h2 {
+  margin: 0 0 1.5rem 0;
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.image-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.25rem;
+  grid-auto-rows: minmax(200px, auto);
+}
+
+.gallery-card {
+  background: #f8fafc;
+  border-radius: 1rem;
+  padding: 0.75rem;
+  transition: transform 0.3s;
+  border: 1px solid #e2e8f0;
+}
+
+.gallery-card:hover {
+  transform: scale(1.02);
+}
+
+.gallery-card:nth-child(3n + 1) {
+  grid-row: span 2;
+}
+
+.gallery-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.75rem;
+  margin-bottom: 0.75rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.gallery-card h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.gallery-card p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.5;
+}
+
+/* Source cards with platform branding */
+.source-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.source-card {
+  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transition: all 0.3s;
+  border: 1px solid #e2e8f0;
+  position: relative;
+  overflow: hidden;
+}
+
+.source-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--platform-color) 0%, transparent 100%);
+}
+
+/* YouTube red */
+.source-card:nth-child(1) {
+  --platform-color: #ff0000;
+}
+
+.source-card:nth-child(1) .chip {
+  background: #ff000015;
+  color: #c70000;
+}
+
+/* Reddit orange */
+.source-card:nth-child(2) {
+  --platform-color: #ff4500;
+}
+
+.source-card:nth-child(2) .chip {
+  background: #ff450015;
+  color: #cc3700;
+}
+
+/* Instagram gradient */
+.source-card:nth-child(3) {
+  --platform-color: #e1306c;
+}
+
+.source-card:nth-child(3) .chip {
+  background: linear-gradient(45deg, #f58529, #dd2a7b, #8134af);
+  color: #fff;
+}
+
+/* Manual/Custom purple */
+.source-card:nth-child(4) {
+  --platform-color: #8b5cf6;
+}
+
+.source-card:nth-child(4) .chip {
+  background: #8b5cf615;
+  color: #6d28d9;
+}
+
+.source-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.source-card h2 {
+  margin: 0.75rem 0 0.5rem 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.4;
+}
+
+.source-card p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.chip {
+  display: inline-block;
+  margin: 0;
+  border-radius: 999px;
+  background: #e2e8f0;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Filter controls */
+.controls {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e2e8f0;
+}
+
+.controls h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.controls > div:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  border: 2px solid #e2e8f0;
+  border-radius: 999px;
+  background: #f8fafc;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: all 0.2s;
+  color: #475569;
+}
+
+.pill:hover {
+  border-color: #cbd5e1;
+  background: #f1f5f9;
+}
+
+.pill.active {
+  border-color: #1e293b;
+  background: #1e293b;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(30, 41, 59, 0.3);
+}
+
+/* Feed grid with masonry */
+.feed-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.feed-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transition: all 0.3s;
+  border: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.feed-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  border-color: #cbd5e1;
+}
+
+/* Random span for visual interest */
+.feed-card:nth-child(5n + 1) {
+  grid-row: span 2;
+}
+
+.feed-card:nth-child(7n + 3) {
+  grid-row: span 2;
+}
+
+.feed-card h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1.4;
+}
+
+.feed-card p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.feed-card a {
+  color: #3b82f6;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin-top: auto;
+  transition: color 0.2s;
+}
+
+.feed-card a:hover {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.meta {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.tag {
+  background: #dbeafe;
+  color: #1e40af;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+/* Admin panels */
+.manual-panel {
+  background: #fff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  margin-bottom: 2rem;
+  border: 1px solid #e2e8f0;
+}
+
+.manual-panel h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.manual-panel > p {
+  margin: 0 0 1.5rem 0;
+  color: #64748b;
+}
+
+.manual-form,
+.admin-resource-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.resource-editor-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  background: #f8fafc;
+}
+
+.error-text {
+  color: #dc2626;
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+/* Form elements */
+input,
+textarea,
+button,
+select {
+  font: inherit;
+}
+
+input,
+textarea,
+select {
+  border: 2px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  transition: all 0.2s;
+  color: #0f172a;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+button {
+  border: none;
+  border-radius: 0.75rem;
+  background: #1e293b;
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+button:hover {
+  background: #0f172a;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .hero {
+    padding: 1.5rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .default-highlights,
+  .resource-grid,
+  .feed-grid {
+    grid-template-columns: 1fr;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .resource-card,
+  .feed-card {
+    grid-column: span 1 !important;
   }
-}
 
-.card {
-  padding: 2em;
-}
+  .source-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
 
-.read-the-docs {
-  color: #888;
+  .image-gallery-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,584 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useMemo, useState } from 'react'
 import './App.css'
 
+const ADMIN_USERNAME = 'ali+2@juristai.org'
+const ADMIN_PASSWORD = 'AtticusDev1234@'
+
+const CATEGORY_ORDER = [
+  'all',
+  'tech',
+  'philosophy',
+  'literature',
+  'humanities',
+  'fashion',
+  'dining',
+  'maqha',
+  'film',
+  'martial-arts',
+  'motorcycling',
+]
+
+const SOURCE_LABELS = {
+  reddit: 'Reddit',
+  youtube: 'YouTube',
+  instagram: 'Instagram',
+  manual: 'Manual',
+}
+
+const INITIAL_PROFILE_LINKS = [
+  {
+    id: 'youtube-latest',
+    label: 'My Most Recent Youtube Video',
+    description: 'Open your latest YouTube upload feed.',
+    link: 'https://www.youtube.com/@Alishukriamin',
+  },
+  {
+    id: 'instagram-latest',
+    label: 'My Most Recent Instagram Post',
+    description: 'Open your latest Instagram activity.',
+    link: 'https://www.instagram.com/alishukriamin/',
+  },
+  {
+    id: 'reddit-latest',
+    label: 'My Most Recent Reddit Post',
+    description: 'Open your newest Reddit posts and comments.',
+    link: 'https://www.reddit.com/user/aibnsamin1/',
+  },
+  {
+    id: 'publication-latest',
+    label: 'My Most Recent Publication',
+    description: 'Open your latest publication and books page.',
+    link: 'https://www.amazon.com/stores/Ali-Shukri-Amin/author/B0FDY9Z5M8',
+  },
+  {
+    id: 'reading-current',
+    label: 'What I am Currently Reading',
+    description: 'Open your StoryGraph reading profile.',
+    link: 'https://app.thestorygraph.com/profile/alishukriamin',
+  },
+  {
+    id: 'restaurant-latest',
+    label: 'Latest Restaurant Review',
+    description: 'Open your most recent Beli dining review activity.',
+    link: 'https://beliapp.co/app/aliflaneur',
+  },
+  {
+    id: 'game-latest',
+    label: 'Latest Game Played',
+    description: 'Open your newest game activity on Stash.',
+    link: 'https://stash.games/users/alishukriamin',
+  },
+  {
+    id: 'islamic-blog-latest',
+    label: 'My Most Recent Islamic Blog Post',
+    description: 'Are Sufis Mushrik or Are Salafis Extremists? | A New Analysis of Istighātha & Tawassul',
+    link: 'https://www.youtube.com/watch?v=reIL-x_tf2w',
+  },
+  {
+    id: 'philosophy-blog-latest',
+    label: 'My Most Recent Philosophy Blog Post',
+    description: 'Open your newest philosophy post.',
+    link: 'https://asaphilosophy.wordpress.com',
+  },
+  {
+    id: 'humanities-blog-latest',
+    label: 'My Most Recent Humanities Blog Post',
+    description: 'Open your latest humanities writing.',
+    link: 'https://asahumanities.wordpress.com',
+  },
+]
+
+const INITIAL_IJAZAT = [
+  {
+    id: 'ijazah-1',
+    title: 'Ijazah Placeholder',
+    imageUrl:
+      'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=1200&q=80',
+    description: 'Replace with your actual ijazah image and details.',
+  },
+]
+
+const INITIAL_ITEMS = [
+  {
+    id: 'yt-1',
+    source: 'youtube',
+    type: 'video',
+    title: 'Are Sufis Mushrik or Are Salafis Extremists? | A New Analysis of Istighātha & Tawassul',
+    summary: 'Latest featured lecture exploring Istighātha and Tawassul with a new analysis.',
+    link: 'https://www.youtube.com/watch?v=reIL-x_tf2w',
+    publishedAt: '2026-02-15T15:20:00Z',
+    tags: ['tech', 'humanities'],
+  },
+  {
+    id: 'rd-1',
+    source: 'reddit',
+    type: 'post',
+    title: 'Reddit Post: Thoughts on AI, Justice, and Access',
+    summary: 'Discussion around practical legal tooling for underserved communities.',
+    link: 'https://reddit.com/user/aibnsamin1',
+    publishedAt: '2026-02-15T12:35:00Z',
+    tags: ['tech', 'philosophy'],
+  },
+  {
+    id: 'ig-1',
+    source: 'instagram',
+    type: 'image',
+    title: 'Instagram: New coffee ritual at maqha',
+    summary: 'A photo set featuring tea and coffee tasting notes.',
+    link: 'https://instagram.com/alishukriamin',
+    publishedAt: '2026-02-14T10:00:00Z',
+    tags: ['maqha', 'dining'],
+  },
+  {
+    id: 'manual-1',
+    source: 'manual',
+    type: 'entry',
+    title: 'Bookshelf update: Newly published titles now live on Amazon',
+    summary: 'Published books are now visible via your Amazon author page in the hub.',
+    link: 'https://www.amazon.com/stores/Ali-Shukri-Amin/author/B0FDY9Z5M8',
+    publishedAt: '2026-02-15T18:10:00Z',
+    tags: ['literature', 'humanities'],
+  },
+  {
+    id: 'manual-2',
+    source: 'manual',
+    type: 'entry',
+    title: 'Reading tracker: StoryGraph profile synced',
+    summary: 'Current reading list and progress are linked from your unified dashboard.',
+    link: 'https://app.thestorygraph.com/profile/alishukriamin',
+    publishedAt: '2026-02-14T20:45:00Z',
+    tags: ['literature', 'philosophy'],
+  },
+]
+
+const formatDate = (isoDate) =>
+  new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(isoDate))
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [items, setItems] = useState(INITIAL_ITEMS)
+  const [profileLinks, setProfileLinks] = useState(INITIAL_PROFILE_LINKS)
+  const [ijazatGallery, setIjazatGallery] = useState(INITIAL_IJAZAT)
+  const [activeCategory, setActiveCategory] = useState('all')
+  const [activeSource, setActiveSource] = useState('all')
+  const [manualTitle, setManualTitle] = useState('')
+  const [manualSummary, setManualSummary] = useState('')
+  const [manualTags, setManualTags] = useState('')
+
+  const [loginUsername, setLoginUsername] = useState('')
+  const [loginPassword, setLoginPassword] = useState('')
+  const [loginError, setLoginError] = useState('')
+  const [isAdminAuthenticated, setIsAdminAuthenticated] = useState(false)
+
+  const [galleryTitle, setGalleryTitle] = useState('')
+  const [galleryDescription, setGalleryDescription] = useState('')
+  const [galleryImageUrl, setGalleryImageUrl] = useState('')
+
+  const normalizedPath = window.location.pathname.replace(/\/+$/, '') || '/'
+  const isAdminRoute = normalizedPath === '/admin'
+
+  const filteredItems = useMemo(() => {
+    return [...items]
+      .filter((item) => activeSource === 'all' || item.source === activeSource)
+      .filter(
+        (item) => activeCategory === 'all' || item.tags.includes(activeCategory),
+      )
+      .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
+  }, [activeCategory, activeSource, items])
+
+  const latestBySource = useMemo(() => {
+    return ['youtube', 'reddit', 'instagram', 'manual'].map((source) => {
+      const latest = [...items]
+        .filter((item) => item.source === source)
+        .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))[0]
+
+      return { source, latest }
+    })
+  }, [items])
+
+  const handleManualSubmit = (event) => {
+    event.preventDefault()
+
+    const title = manualTitle.trim()
+    const summary = manualSummary.trim()
+    const tags = manualTags
+      .split(',')
+      .map((tag) => tag.trim().toLowerCase())
+      .filter(Boolean)
+
+    if (!title || !summary) {
+      return
+    }
+
+    setItems((previous) => [
+      {
+        id: `manual-${Date.now()}`,
+        source: 'manual',
+        type: 'entry',
+        title,
+        summary,
+        link: '#',
+        publishedAt: new Date().toISOString(),
+        tags: tags.length > 0 ? tags : ['humanities'],
+      },
+      ...previous,
+    ])
+
+    setManualTitle('')
+    setManualSummary('')
+    setManualTags('')
+  }
+
+  const handleLoginSubmit = (event) => {
+    event.preventDefault()
+
+    if (loginUsername === ADMIN_USERNAME && loginPassword === ADMIN_PASSWORD) {
+      setIsAdminAuthenticated(true)
+      setLoginError('')
+      return
+    }
+
+    setLoginError('Invalid admin credentials.')
+  }
+
+  const handleProfileLinkChange = (id, field, value) => {
+    setProfileLinks((previous) =>
+      previous.map((resource) =>
+        resource.id === id ? { ...resource, [field]: value } : resource,
+      ),
+    )
+  }
+
+  const handleGallerySubmit = (event) => {
+    event.preventDefault()
+
+    const title = galleryTitle.trim()
+    const description = galleryDescription.trim()
+    const imageUrl = galleryImageUrl.trim()
+
+    if (!title || !imageUrl) {
+      return
+    }
+
+    const newItem = {
+      id: `ijazah-${Date.now()}`,
+      title,
+      description,
+      imageUrl,
+    }
+
+    setIjazatGallery((previous) => [newItem, ...previous])
+
+    setGalleryTitle('')
+    setGalleryDescription('')
+    setGalleryImageUrl('')
+  }
+
+  const handleLogout = () => {
+    setIsAdminAuthenticated(false)
+    setLoginPassword('')
+  }
+
+  if (isAdminRoute && !isAdminAuthenticated) {
+    return (
+      <main className="login-page">
+        <section className="login-card">
+          <p className="eyebrow">AliHub Admin</p>
+          <h1>Admin Login</h1>
+          <p>Only the admin can access manual controls and content updates.</p>
+          <form onSubmit={handleLoginSubmit} className="manual-form">
+            <input
+              type="email"
+              value={loginUsername}
+              onChange={(event) => setLoginUsername(event.target.value)}
+              placeholder="Username"
+              autoComplete="username"
+            />
+            <input
+              type="password"
+              value={loginPassword}
+              onChange={(event) => setLoginPassword(event.target.value)}
+              placeholder="Password"
+              autoComplete="current-password"
+            />
+            {loginError ? <p className="error-text">{loginError}</p> : null}
+            <button type="submit">Login as Admin</button>
+          </form>
+        </section>
+      </main>
+    )
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
+    <main className="page">
+      <header className="hero">
+        <div className="hero-top-row">
+          <p className="eyebrow">AliHub — single pane of glass</p>
+          {isAdminRoute ? (
+            <button type="button" className="logout-button" onClick={handleLogout}>
+              Log out
+            </button>
+          ) : (
+            <a className="logout-button" href="/admin">
+              Admin
+            </a>
+          )}
+        </div>
+        <a
+          className="github-banner-link"
+          href="https://github.com/AliSMAmin"
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Ali GitHub profile"
+        >
+          <img
+            className="github-banner"
+            src="https://camo.githubusercontent.com/c966e6549a477ccfda0662ba936145716368d536e756f6e44e4485bd6eef75da/68747470733a2f2f6769746875622d726561646d652d73747265616b2d73746174732e6865726f6b756170702e636f6d2f3f757365723d416c69534d416d696e267468656d653d746f6b796f6e6967687426686964655f626f726465723d74727565"
+            alt="Ali GitHub stats banner"
+          />
         </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+
+        <h1>Ali&apos;s Unified Portfolio Feed</h1>
         <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
+          Latest activity from YouTube, Reddit, Instagram, books, reading, movies,
+          fine dining, and manually curated updates in one dashboard.
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </header>
+
+      <section className="default-highlights" aria-label="Default featured updates">
+        <article className="highlight-card">
+          <p className="highlight-label">Carousel slide 1</p>
+          <h2>Is Bitcoin Halal?: Cryptocurrencies, Blockchain, and the Shari'a</h2>
+          <p className="highlight-meta">by Ali Amin</p>
+          <p>
+            Ali Shukri Amin&apos;s work, &quot;Is Bitcoin Halal?&quot; explores the permissibility
+            of cryptocurrencies, particularly Bitcoin, within Islamic law. The
+            discussion delves into Islamic concepts such as Shari&apos;a, Fiqh, and
+            Fatwa, as well as economic principles and the mechanics of modern
+            financial systems.
+          </p>
+          <p className="highlight-note">To buy, select a Format:</p>
+        </article>
+
+        <div className="highlight-grid">
+          <article className="mini-highlight">
+            <h3>Featured Islamic analysis</h3>
+            <p className="mini-title">Are Sufis Mushrik or Are Salafis Extremists?</p>
+            <a href="https://www.youtube.com/watch?v=reIL-x_tf2w" target="_blank" rel="noreferrer">
+              Watch on YouTube
+            </a>
+          </article>
+
+          <article className="mini-highlight">
+            <h3>Currently reading</h3>
+            <p className="mini-brand">Oneworld</p>
+            <p className="mini-title">Salafism: Between Fact and Fiction</p>
+            <p>Yasir Qadhi</p>
+          </article>
+
+          <article className="mini-highlight">
+            <h3>Recent reviews</h3>
+            <p className="mini-title">Resurrection (2025)</p>
+            <p>★★★★★ Liked · Watched 15 Feb 2026</p>
+            <p>
+              Seen at the National Museum of Asian Art, Freer Gallery: The motion
+              picture itself is a rebellion against the ephemeral nature of life.
+            </p>
+          </article>
+
+          <article className="mini-highlight">
+            <h3>Most recent fine dining</h3>
+            <p className="mini-title">Oyamel Cocina in DC</p>
+          </article>
+
+          <article className="mini-highlight">
+            <h3>Currently playing</h3>
+            <p className="mini-title">Enderal: Forgotten Stories</p>
+          </article>
+        </div>
+      </section>
+
+      <section className="resource-grid" aria-label="Ali profile resources">
+        {profileLinks.map((resource) => (
+          <article key={resource.id} className="resource-card">
+            <h2>{resource.label}</h2>
+            <p>{resource.description}</p>
+            <a href={resource.link} target="_blank" rel="noreferrer">
+              Visit link
+            </a>
+          </article>
+        ))}
+      </section>
+
+      <section className="gallery-section">
+        <h2>Islamic Ijazat Gallery</h2>
+        <div className="image-gallery-grid">
+          {ijazatGallery.map((item) => (
+            <article key={item.id} className="gallery-card">
+              <img src={item.imageUrl} alt={item.title} loading="lazy" />
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="source-grid">
+        {latestBySource.map(({ source, latest }) => (
+          <article key={source} className="source-card">
+            <p className="chip">{SOURCE_LABELS[source]}</p>
+            <h2>{latest ? latest.title : 'No items yet'}</h2>
+            <p>{latest ? latest.summary : 'Connect this source to populate data.'}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="controls">
+        <div>
+          <h3>Category</h3>
+          <div className="pill-row">
+            {CATEGORY_ORDER.map((category) => (
+              <button
+                key={category}
+                className={category === activeCategory ? 'pill active' : 'pill'}
+                onClick={() => setActiveCategory(category)}
+                type="button"
+              >
+                {category}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3>Source</h3>
+          <div className="pill-row">
+            {['all', 'reddit', 'youtube', 'instagram', 'manual'].map((source) => (
+              <button
+                key={source}
+                className={source === activeSource ? 'pill active' : 'pill'}
+                onClick={() => setActiveSource(source)}
+                type="button"
+              >
+                {source}
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="feed-grid">
+        {filteredItems.map((item) => (
+          <article key={item.id} className="feed-card">
+            <p className="meta">
+              {SOURCE_LABELS[item.source]} · {formatDate(item.publishedAt)}
+            </p>
+            <h2>{item.title}</h2>
+            <p>{item.summary}</p>
+            <div className="tag-row">
+              {item.tags.map((tag) => (
+                <span key={`${item.id}-${tag}`} className="tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <a href={item.link} target="_blank" rel="noreferrer">
+              Open source
+            </a>
+          </article>
+        ))}
+      </section>
+
+      {isAdminRoute ? (
+        <>
+              <section className="manual-panel">
+                <h3>Manual curation</h3>
+                <p>Add your own updates so you always stay in control of the narrative.</p>
+                <form onSubmit={handleManualSubmit} className="manual-form">
+                  <input
+                    value={manualTitle}
+                    onChange={(event) => setManualTitle(event.target.value)}
+                    placeholder="Update title"
+                  />
+                  <textarea
+                    value={manualSummary}
+                    onChange={(event) => setManualSummary(event.target.value)}
+                    placeholder="Short summary"
+                    rows={3}
+                  />
+                  <input
+                    value={manualTags}
+                    onChange={(event) => setManualTags(event.target.value)}
+                    placeholder="tags,comma,separated"
+                  />
+                  <button type="submit">Add manual update</button>
+                </form>
+              </section>
+
+              <section className="manual-panel">
+                <h3>Admin: Update Platform Links</h3>
+                <p>Edit labels, descriptions, and links for each platform card.</p>
+                <div className="admin-resource-list">
+                  {profileLinks.map((resource) => (
+                    <article key={resource.id} className="resource-editor-card">
+                      <input
+                        value={resource.label}
+                        onChange={(event) =>
+                          handleProfileLinkChange(resource.id, 'label', event.target.value)
+                        }
+                        placeholder="Label"
+                      />
+                      <textarea
+                        rows={2}
+                        value={resource.description}
+                        onChange={(event) =>
+                          handleProfileLinkChange(resource.id, 'description', event.target.value)
+                        }
+                        placeholder="Description"
+                      />
+                      <input
+                        value={resource.link}
+                        onChange={(event) =>
+                          handleProfileLinkChange(resource.id, 'link', event.target.value)
+                        }
+                        placeholder="https://..."
+                      />
+                    </article>
+                  ))}
+                </div>
+              </section>
+
+              <section className="manual-panel">
+                <h3>Admin: Add Gallery Image</h3>
+                <p>Add new image cards to Islamic ijazat.</p>
+                <form onSubmit={handleGallerySubmit} className="manual-form">
+                  <input
+                    value={galleryTitle}
+                    onChange={(event) => setGalleryTitle(event.target.value)}
+                    placeholder="Image title"
+                  />
+                  <textarea
+                    value={galleryDescription}
+                    onChange={(event) => setGalleryDescription(event.target.value)}
+                    placeholder="Short description"
+                    rows={2}
+                  />
+                  <input
+                    value={galleryImageUrl}
+                    onChange={(event) => setGalleryImageUrl(event.target.value)}
+                    placeholder="https://image-url"
+                  />
+                  <button type="submit">Add gallery image</button>
+                </form>
+              </section>
+        </>
+      ) : null}
+    </main>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,10 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+* {
+  box-sizing: border-box;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
+html,
+body,
+#root {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  min-height: 100%;
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: '../build',
+    emptyOutDir: true,
+  },
 })

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "portfolio",
+  "private": true,
+  "scripts": {
+    "install:frontend": "npm --prefix frontend install",
+    "dev": "npm --prefix frontend run dev",
+    "build": "npm --prefix frontend run build",
+    "preview": "npm --prefix frontend run preview"
+  }
+}


### PR DESCRIPTION
### Motivation
- Remove the redundant Secular Degrees & Accomplishments carousel and simplify the admin gallery flow to focus on Islamic ijazat items only.
- Move the app toward a cleaner, editorial look with serif headings and cooler slate tones (less brown) across the dashboard.
- Preserve the featured Islamic analysis default highlight and seeded feed content so the public dashboard shows the requested item.

### Description
- Removed rendering and state for the secular gallery and the gallery-type selector, and changed admin gallery submissions to always create `ijazah-*` items in `frontend/src/App.jsx`.
- Overhauled visual styles in `frontend/src/App.css` (serif-first typography, cooler hero background, 12-column resource/feed grid layout, toned-down source card colors) and simplified `frontend/src/index.css`.
- Added client-side admin auth constants, route handling, manual curation, filtering logic (`CATEGORY_ORDER`, `SOURCE_LABELS`, `filteredItems`, `latestBySource`) and kept the seeded YouTube highlight in `frontend/src/App.jsx`.
- Updated build configuration and project scripts by adjusting `frontend/vite.config.js`, adding a top-level `package.json` for helper scripts, and added `.gitignore` entries.

### Testing
- Ran `npm run build` which completed successfully and produced frontend build artifacts.
- Launched the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served at the expected address.
- Captured a Playwright full-page screenshot of `http://127.0.0.1:4173/` to validate the UI changes and removal of the secular section, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993afb800348326b4197b8cae78ebc4)