### PR TITLE
Render small social icons on portfolio cards

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -205,6 +205,21 @@ body {
   font-weight: 700;
 }
 
+
+.section-label-with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.social-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 0.2rem;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
 .dot-row {
   display: flex;
   gap: 0.45rem;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,13 @@ import salafismCover from './assets/CurrentReads/understanding-salafism-97817860
 import awsCert from './assets/secularDiplomas/AWS-SAA.png'
 import blockchainCert from './assets/secularDiplomas/Certified Blockchain Expert.png'
 import mastersDegree from './assets/secularDiplomas/mastersdegree.png'
+import youtubeIcon from './assets/Icons/youtube.png'
+import githubIcon from './assets/Icons/github.png'
+import redditIcon from './assets/Icons/Reddit-Logo-1958974045.jpg'
+import stashIcon from './assets/Icons/stash-game-collection-tracker-logo-766785159.jpg'
+import letterboxdIcon from './assets/Icons/letterboxd-logo-alt-v-neg-rgb-1000px.png'
+import storyGraphIcon from './assets/Icons/Logo_for_The_StoryGraph.png'
+import beliIcon from './assets/Icons/Beli+Logo_FINAL070423.webp'
 
 const ijazatImages = Object.entries(
   import.meta.glob('./assets/Ijazat/*.{png,jpg,jpeg,JPG,JPEG,webp}', {
@@ -170,6 +177,17 @@ const DEFAULT_IMAGE_SELECTIONS = {
   cardHumanitiesBlog: 'blockchainCert',
 }
 
+
+const CARD_ICONS = {
+  youtube: { src: youtubeIcon, alt: 'YouTube icon' },
+  github: { src: githubIcon, alt: 'GitHub icon' },
+  movie: { src: letterboxdIcon, alt: 'Letterboxd icon' },
+  restaurant: { src: beliIcon, alt: 'Beli icon' },
+  playing: { src: stashIcon, alt: 'Stash icon' },
+  reading: { src: storyGraphIcon, alt: 'StoryGraph icon' },
+  reddit: { src: redditIcon, alt: 'Reddit icon' },
+}
+
 const getImageSrc = (selections, key) => IMAGE_LIBRARY[selections[key]]?.src ?? aliPortrait
 
 const ADMIN_USERNAME = 'ali+2@juristai.org'
@@ -227,6 +245,17 @@ function App() {
   const secularGallery = useMemo(() => secularImages, [])
 
   const activeHeroItem = heroSlides[activeSlide]
+
+  const renderSectionLabel = (label, cardId) => {
+    const icon = CARD_ICONS[cardId]
+
+    return (
+      <p className="section-label section-label-with-icon">
+        {icon ? <img src={icon.src} alt={icon.alt} className="social-icon" /> : null}
+        <span>{label}</span>
+      </p>
+    )
+  }
 
   const adminControls = [
     { key: 'heroPortrait', label: 'Hero Portrait' },
@@ -370,7 +399,7 @@ function App() {
 
       <section className="card-grid top-grid" aria-label="Top cards">
         <article className="card youtube-card">
-          <p className="section-label">Most Recent Islamic YouTube Video</p>
+          {renderSectionLabel('Most Recent Islamic YouTube Video', 'youtube')}
           <iframe
             src="https://www.youtube.com/embed/reIL-x_tf2w"
             title="Most recent Islamic YouTube video"
@@ -380,7 +409,7 @@ function App() {
         </article>
 
         <article className="card github-card">
-          <p className="section-label">GitHub Contributions</p>
+          {renderSectionLabel('GitHub Contributions', 'github')}
           <a href="https://github.com/AliSMAmin" target="_blank" rel="noreferrer">
             <img
               src="https://ghchart.rshah.org/AliSMAmin"
@@ -395,7 +424,7 @@ function App() {
         </article>
 
         <article className="card movie-card">
-          <p className="section-label">{TOP_MOVIE_CARD.label}</p>
+          {renderSectionLabel(TOP_MOVIE_CARD.label, 'movie')}
           <img src={getImageSrc(imageSelections, 'topMovieCard')} alt={TOP_MOVIE_CARD.title} className="card-image" />
           <h3>{TOP_MOVIE_CARD.title}</h3>
           <p>{TOP_MOVIE_CARD.description}</p>
@@ -405,7 +434,7 @@ function App() {
         </article>
 
         <article className="card restaurant-card">
-          <p className="section-label">Most Recent Restaurant Review</p>
+          {renderSectionLabel('Most Recent Restaurant Review', 'restaurant')}
           <img
             src={restaurantCarouselImages[activeRestaurantSlide]}
             alt="Restaurant review image"
@@ -421,7 +450,7 @@ function App() {
       <section className="card-grid multi" aria-label="Content cards">
         {CONTENT_CARDS.filter((card) => !['youtube', 'github', 'restaurant'].includes(card.id)).map((card) => (
           <article key={card.id} className="card">
-            <p className="section-label">{card.label}</p>
+            {renderSectionLabel(card.label, card.id)}
             {card.id !== 'reddit' ? (
               <img src={getImageSrc(imageSelections, contentCardImageMap[card.id])} alt={card.title} className="inline-card-image" />
             ) : null}


### PR DESCRIPTION
### Motivation
- Make each content/social card visually identify its platform by showing the platform icon alongside the section label as a small, non-intrusive indicator.

### Description
- Imported new icon assets and mapped them to card ids via a `CARD_ICONS` lookup in `frontend/src/App.jsx`.
- Added a shared renderer `renderSectionLabel(label, cardId)` and replaced the hard-coded section labels for top cards and content cards to use it so icons appear when available.
- Added compact styling in `frontend/src/App.css` (`.section-label-with-icon` and `.social-icon`) to keep icons small and aligned with labels.
- Modified files: `frontend/src/App.jsx` and `frontend/src/App.css`.

### Testing
- Executed `npm run build` in `frontend/` and the build completed successfully (assets emitted including the new icons). 
- Launched the dev server (`vite`) and captured a visual smoke-check screenshot via an automated Playwright script, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699774ac89d083269fdef7f0635e04d9)