### PR TITLE
Update hero carousel images and add profile description

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -139,6 +139,14 @@ body {
   font-family: 'Playfair Display', 'Crimson Pro', Georgia, serif;
 }
 
+.hero-description {
+  margin: 0;
+  max-width: 70ch;
+  font-size: clamp(0.95rem, 1.9vw, 1.1rem);
+  line-height: 1.6;
+  color: #334155;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -169,10 +177,11 @@ body {
 
 .main-carousel img {
   width: 100%;
-  height: 100%;
-  min-height: 280px;
-  object-fit: cover;
+  height: auto;
+  max-height: clamp(260px, 42vw, 460px);
+  object-fit: contain;
   border-radius: 0.75rem;
+  background: #f8fafc;
 }
 
 .main-carousel h2 {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,8 +4,8 @@ import './App.css'
 import aliPortrait from './assets/PicturesOfAli/8.0.jpg'
 import aliSuitPortrait from './assets/PicturesOfAli/8.7 (8.7) Suit (Editted).jpg'
 import bitcoinBookCover from './assets/Publications/Is Bitcoin Halal.jpg'
-import enderalCover from './assets/Games/Enderal.jpg'
-import salafismCover from './assets/CurrentReads/understanding-salafism-9781786078483_hr-923828085.jpg'
+import enderalCover from './assets/Games/CurrentlyPlaying/Enderal.jpg'
+import salafismCover from './assets/Books/CurrentReads/understanding-salafism-9781786078483_hr-923828085.jpg'
 import awsCert from './assets/secularDiplomas/AWS-SAA.png'
 import blockchainCert from './assets/secularDiplomas/Certified Blockchain Expert.png'
 import mastersDegree from './assets/secularDiplomas/mastersdegree.png'
@@ -164,6 +164,7 @@ const CONTENT_CARDS = [
 
 const HERO_CAROUSEL_SLIDES = [TOP_MOVIE_CARD, ...CONTENT_CARDS].map((card) => ({
   id: `slide-${card.id}`,
+  cardId: card.id,
   title: card.label,
   description: card.description,
   link: card.link,
@@ -204,6 +205,21 @@ const CARD_ICONS = {
 
 const getImageSrc = (selections, key) => IMAGE_LIBRARY[selections[key]]?.src ?? aliPortrait
 
+const heroSlideImageMap = {
+  movie: 'topMovieCard',
+  reading: 'cardReading',
+  'favorite-books': 'cardFavoriteBooks',
+  playing: 'cardPlaying',
+  'favorite-games': 'cardFavoriteGames',
+  watching: 'cardWatching',
+  'favorite-shows': 'cardFavoriteShows',
+  instagram: 'cardInstagram',
+  reddit: 'heroSlideDefault',
+  'islamic-blog': 'cardIslamicBlog',
+  'philosophy-blog': 'cardPhilosophyBlog',
+  'humanities-blog': 'cardHumanitiesBlog',
+}
+
 const ADMIN_USERNAME = 'ali+2@juristai.org'
 const ADMIN_PASSWORD = 'AtticusDev1234@'
 
@@ -242,7 +258,11 @@ function App() {
   }
 
   const heroSlides = useMemo(
-    () => HERO_CAROUSEL_SLIDES.map((slide) => ({ ...slide, image: getImageSrc(imageSelections, 'heroSlideDefault') })),
+    () =>
+      HERO_CAROUSEL_SLIDES.map((slide) => ({
+        ...slide,
+        image: getImageSrc(imageSelections, heroSlideImageMap[slide.cardId] ?? 'heroSlideDefault'),
+      })),
     [imageSelections],
   )
 
@@ -397,6 +417,10 @@ function App() {
       <header className="hero">
         <img className="hero-portrait" src={getImageSrc(imageSelections, 'heroPortrait')} alt="Ali Shukri Amin" />
         <h1>Ali Shukri Amin&apos;s Portfolio</h1>
+        <p className="hero-description">
+          Ṭālib al-&apos;Ilm☝Muwahhid 🇸🇩 • Tech CEO &amp; MS IT/SWE • Qira&apos;āt, Hadīth, Aqīda, Fiqh, Ihsān • Former
+          Prisoner • Phil, Psych, Geopolitics, MENA, literature, movies, dining, coffee, tea, fashion, motorcycling
+        </p>
       </header>
 
       <section className="main-carousel" aria-label="Main content carousel">


### PR DESCRIPTION
### Motivation
- Fix broken/incorrect image imports so the app references the current asset locations and show the correct images for each carousel topic. 
- Make the top carousel choose images relevant to the slide content and ensure the visual layout adapts to varying image sizes. 
- Add an overall personal description under the hero portrait as requested.

### Description
- Updated import paths for `Enderal` and the current-reading cover to their actual asset locations so the images resolve correctly. 
- Added `cardId` to each hero slide and introduced `heroSlideImageMap` to select a topic-appropriate image per slide instead of a single static default. 
- Updated `heroSlides` to resolve each slide image from `imageSelections` using the new mapping, and preserved the admin controls for image selection. 
- Added the requested profile description text under the top portrait and added `.hero-description` CSS, and changed main carousel image rules to `height: auto`, `object-fit: contain`, bounded `max-height`, and a subtle background to make images fit dynamically.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Launched the dev server (`npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173`) and captured a full-page screenshot via an automated Playwright script to verify layout and images were rendered as expected. 
- Committed the changes and validated the diff contains updates to `frontend/src/App.jsx` and `frontend/src/App.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb1922ce883269a58a1a423fa0d58)