### PR TITLE
Update hero profile image to recent portrait

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
-import aliPortrait from './assets/PicturesOfAli/8.0.jpg'
+import aliPortrait from './assets/PicturesOfAli/9.3 (edit).jpg'
 import aliSuitPortrait from './assets/PicturesOfAli/8.7 (8.7) Suit (Editted).jpg'
 import bitcoinBookCover from './assets/Publications/Is Bitcoin Halal.jpg'
 import enderalCover from './assets/Games/CurrentlyPlaying/Enderal.jpg'


### PR DESCRIPTION
### Motivation
- Ensure the top hero/profile picture shows the most recent portrait by switching the default `aliPortrait` import to the newer image file.

### Description
- Replace the imported hero image in `frontend/src/App.jsx` so `aliPortrait` uses `./assets/PicturesOfAli/9.3 (edit).jpg` instead of the older `8.0.jpg`.

### Testing
- Built the frontend with `npm --prefix frontend run build` (succeeded) and launched the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of the updated hero section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df41705fc83269f9181c4942df301)