### PR TITLE
Remove hardcoded admin credentials from frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -220,8 +220,8 @@ const heroSlideImageMap = {
   'humanities-blog': 'cardHumanitiesBlog',
 }
 
-const ADMIN_USERNAME = 'ali+2@juristai.org'
-const ADMIN_PASSWORD = 'AtticusDev1234@'
+const ADMIN_USERNAME = import.meta.env.VITE_ADMIN_USERNAME ?? ''
+const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD ?? ''
 
 function App() {
   const [activeSlide, setActiveSlide] = useState(0)
@@ -314,7 +314,7 @@ function App() {
 
   const handleAdminLogin = (event) => {
     event.preventDefault()
-    if (adminUsername === ADMIN_USERNAME && adminPassword === ADMIN_PASSWORD) {
+    if (ADMIN_USERNAME && ADMIN_PASSWORD && adminUsername === ADMIN_USERNAME && adminPassword === ADMIN_PASSWORD) {
       setIsAdminAuthenticated(true)
       setAdminError('')
       setAdminPassword('')


### PR DESCRIPTION
### Motivation
- Remove a hardcoded admin username and password that were committed to the repository to eliminate a leaked secret and allow credentials to be managed via environment variables.

### Description
- Replaced hardcoded `ADMIN_USERNAME` and `ADMIN_PASSWORD` values with `import.meta.env.VITE_ADMIN_USERNAME ?? ''` and `import.meta.env.VITE_ADMIN_PASSWORD ?? ''` in `frontend/src/App.jsx`.
- Tightened the admin login check to require both environment variables to be present before performing the credentials comparison.
- No other behavior changes to the admin UI or build pipeline were made.

### Testing
- Ran `rg -n "AtticusDev1234@|ali\+2@juristai\.org" .` to verify the leaked strings are no longer present and the search returned no matches (success).
- Ran `npm --prefix frontend run build` to ensure the frontend builds successfully with the change (Vite production build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f822574e48326a0d023d15d7812a8)