### PR TITLE
Use Food assets for restaurant card defaults

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,27 @@ const secularImages = Object.entries(
     image: typeof src === 'string' ? src : src?.default,
   }))
 
+const foodImages = Object.entries(
+  import.meta.glob('./assets/Food/*.{png,jpg,jpeg,JPG,JPEG,webp}', {
+    eager: true,
+    query: '?url',
+    import: 'default',
+  }),
+)
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([path, src], index) => {
+    const fileName = path.split('/').pop() ?? `Food Image ${index + 1}`
+    const cleanName = fileName.replace(/\.[^.]+$/, '')
+
+    return {
+      key: `foodImage${index + 1}`,
+      label: `Food: ${cleanName}`,
+      src: typeof src === 'string' ? src : src?.default,
+    }
+  })
+
+const foodImageLibrary = Object.fromEntries(foodImages.map(({ key, label, src }) => [key, { label, src }]))
+
 const IMAGE_LIBRARY = {
   aliPortrait: { label: 'Ali Portrait', src: aliPortrait },
   aliSuitPortrait: { label: 'Ali Suit Portrait', src: aliSuitPortrait },
@@ -66,6 +87,7 @@ const IMAGE_LIBRARY = {
   awsCert: { label: 'AWS-SAA', src: awsCert },
   blockchainCert: { label: 'Certified Blockchain Expert', src: blockchainCert },
   mastersDegree: { label: 'Masters Degree', src: mastersDegree },
+  ...foodImageLibrary,
 }
 
 const IMAGE_OPTIONS = Object.entries(IMAGE_LIBRARY).map(([value, data]) => ({
@@ -201,9 +223,9 @@ const DEFAULT_IMAGE_SELECTIONS = {
   heroPortrait: 'aliPortrait',
   heroSlideDefault: 'bitcoinBookCover',
   topMovieCard: 'aliSuitPortrait',
-  restaurantCarousel1: 'bitcoinBookCover',
-  restaurantCarousel2: 'salafismCover',
-  restaurantCarousel3: 'aliPortrait',
+  restaurantCarousel1: 'foodImage1',
+  restaurantCarousel2: 'foodImage2',
+  restaurantCarousel3: 'foodImage3',
   cardPlaying: 'currentGameCover',
   cardReading: 'salafismCover',
   cardFavoriteBooks: 'favoriteBooksCover',
@@ -211,7 +233,7 @@ const DEFAULT_IMAGE_SELECTIONS = {
   cardWatching: 'currentShowCover',
   cardFavoriteShows: 'favoriteShowCover',
   cardTopMovies: 'aliSuitPortrait',
-  cardFavoriteRestaurants: 'salafismCover',
+  cardFavoriteRestaurants: 'foodImage4',
   cardInstagram: 'aliPortrait',
   cardIslamicBlog: 'aliPortrait',
   cardPhilosophyBlog: 'mastersDegree',


### PR DESCRIPTION
### Motivation
- Restaurant images in the UI were not using the files under `src/assets/Food` because those files were never loaded into the app's shared image library and the restaurant defaults pointed at unrelated images. 
- Make `Food` images available in the admin image selector and ensure restaurant cards/carousels show food photos by default.

### Description
- Add a `foodImages` loader using `import.meta.glob('./assets/Food/*.{png,jpg,jpeg,JPG,JPEG,webp}')` that builds a small metadata list from the `Food` folder. 
- Create `foodImageLibrary` and merge it into the shared `IMAGE_LIBRARY` so food images appear in `IMAGE_OPTIONS` and are admin-selectable. 
- Update `DEFAULT_IMAGE_SELECTIONS` to point restaurant-related keys to food images (`restaurantCarousel1/2/3` → `foodImage1/2/3`, `cardFavoriteRestaurants` → `foodImage4`). 
- Ensure `getImageSrc` and the existing admin controls continue to work with the new entries so the UI and admin panel can select the new food images.

### Testing
- Ran `npm run build` (from `frontend/`) and the build completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and it ran without errors. 
- Executed an automated Playwright script to load the app and capture a screenshot of the updated restaurant section, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7687545608326936f96d9be1bf648)